### PR TITLE
Fix various typos

### DIFF
--- a/csv.3
+++ b/csv.3
@@ -75,7 +75,7 @@ The idea behind parsing with \fBlibcsv\fP is straight-forward: you initialize a 
 end-of-row events.  \fBcsv_parse()\fP parses the data provided calling the
 user-defined callback functions as it reads fields and rows.
 When complete, \fBcsv_fini()\fP is called to finish processing the current
-field and make a final call to the callback functions if neccessary.
+field and make a final call to the callback functions if necessary.
 \fBcsv_free()\fP is then called to free the parser object.
 \fBcsv_error()\fP and \fBcsv_strerror()\fP provide information about errors
 encountered by the functions.
@@ -147,14 +147,14 @@ Multiple options can be specified by OR-ing them together.
 .RE
 
 By default \fIcb2\fP is not called when rows that do not contain any fields
-are encountered.  This behavior is meant to accomodate files using
-only either a linefeed or a carriage return as a record seperator to
+are encountered.  This behavior is meant to accommodate files using
+only either a linefeed or a carriage return as a record separator to
 be parsed properly while at the same time being able to parse files with rows
 terminated by multiple characters from resulting in blank rows after
 each actual row of data (for example, processing a text CSV file
 created that was created on a Windows machine on a Unix machine).
 The \fBCSV_REPALL_NL\fP option will cause \fBcb2\fP to be called
-once for every carraige return or linefeed encountered outside of a field.  
+once for every carriage return or linefeed encountered outside of a field.  
 \fIcb2\fP is called with the character that prompted the call to the function,
 , cast to an unsigned char, either \fBCSV_CR\fP for carriage return, \fBCSV_LF\fP for linefeed, or \fB-1\fP
 for record termination from a call to \fBcsv_fini()\fP (see below).
@@ -178,7 +178,7 @@ functions may be called many times during a single call to \fBcsv_parse()\fP
 depending on the amount of data being processed in a given call.
 .PP
 \fBcsv_parse()\fP returns the number of bytes processed, on a successful
-call this will be \fIlen\fP, if it is less than len an error has occured.
+call this will be \fIlen\fP, if it is less than len an error has occurred.
 An error can occur, for example, if there is insufficient memory
 to store the contents of the current field in the entry buffer.
 An error can also occur if malformed data is encountered while running
@@ -192,7 +192,7 @@ of the error. \fBcsv_error()\fP takes a single argument, a pointer to a
 .PP
 .RS
 .TP
-\fBCSV_EPARSE\fP\ \ \ A parse error has occured while in strict mode
+\fBCSV_EPARSE\fP\ \ \ A parse error has occurred while in strict mode
 .TP
 \fBCSV_ENOMEM\fP\ \ \ There was not enough memory while attempting to increase the entry buffer for the current field
 .TP
@@ -210,7 +210,7 @@ to call the \fBcsv_fini()\fP function.  This function will call the \fIcb1\fP
 function with any remaining data in the entry buffer (if there is
 any) and call the \fIcb2\fP function unless we are already at the end of a row
 (the last byte processed was a newline character for example).
-It is neccessary to call this function because the file being
+It is necessary to call this function because the file being
 processed might not end with a carriage return or newline but the
 data that has been read in to this point still needs to be 
 submitted to the callback routines.
@@ -275,7 +275,7 @@ the number of bytes needed to represent the data, after inserting
 escaping quotes, will be greater than SIZE_MAX.  In such a case,
 csv_write will return SIZE_MAX which should be interpreted as meaning
 the data is too large to write to a single field.  The \fBcsv_fwrite()\fP
-function is not similiarly limited.
+function is not similarly limited.
 
 \fBcsv_fwrite()\fP takes a FILE pointer (which should have been opened in
 binary mode) and converts and writes the data pointed to by \fIsrc\fP
@@ -285,7 +285,7 @@ there was an error writing to the file.
 characters processed or written.  If this functionality is required,
 use the \fBcsv_write()\fP function combined with \fBfwrite()\fP.
 
-\fBcsv_write2()\fP and \fBcsv_fwrite2()\fP work similiarly but take an
+\fBcsv_write2()\fP and \fBcsv_fwrite2()\fP work similarly but take an
 additional argument, the quote character to use when composing the field.
 
 .ti -4
@@ -299,7 +299,7 @@ return the current delimiter and quote characters respectively.  When
 to \fBCSV_QUOTE\fP.  Note that the rest of the CSV conventions still apply
 when these functions are used to change the delimiter and/or quote characters,
 fields containing the new quote character or delimiter must be quoted and quote
-characters must be escaped with an immediately preceeding instance of the same
+characters must be escaped with an immediately preceding instance of the same
 character.
 Additionally, the \fBcsv_set_space_func()\fP and \fBcsv_set_term_func()\fP
 allow a user-defined function to be provided which will be used determine
@@ -333,7 +333,7 @@ reflect the most common usage of the format, namely:
 .PP
 .RS
 .TP
-Fields are seperated with commas.
+Fields are separated with commas.
 .TP
 Rows are delimited by newline sequences (see below).
 .TP
@@ -409,7 +409,7 @@ would be parsed equivalently to the correct form:
 .fi
 This is often desirable as there are some applications that do
 not adhere to the specifications previously discussed.  However,
-there are instances where malformed CSV data is ambigious, namely
+there are instances where malformed CSV data is ambiguous, namely
 when a comma or newline is the next non-space character following
 a quote such as:
 .nf
@@ -420,7 +420,7 @@ This could either be parsed as a single field containing the data:
 
 \fBSally said "Hello", Wally said "Goodbye"\fP
 
-or as 2 seperate fields:
+or as 2 separate fields:
 
 .fi
 \fBSally said "Hello\fP
@@ -431,7 +431,7 @@ Since the data is malformed, there is no way to know if the quote
 before the comma is meant to be a literal quote or if it signifies
 the end of the field.  This is of course not an issue for properly
 formed data as all quotes must be escaped.  \fBlibcsv\fP will parse this
-example as 2 seperate fields.
+example as 2 separate fields.
 
 \fBlibcsv\fP provides a strict mode that will return with a parse error
 if a quote is seen inside a non-quoted field or if a non-escaped

--- a/libcsv.c
+++ b/libcsv.c
@@ -346,7 +346,7 @@ csv_parse(struct csv_parser *p, const void *s, size_t len, void (*cb1)(void *, s
   }
 
   while (pos < len) {
-    /* Check memory usage, increase buffer if neccessary */
+    /* Check memory usage, increase buffer if necessary */
     if (entry_pos == ((p->options & CSV_APPEND_NULL) ? p->entry_size - 1 : p->entry_size) ) {
       if (csv_increase_buffer(p) != 0) {
         p->quoted = quoted, p->pstate = pstate, p->spaces = spaces, p->entry_pos = entry_pos;

--- a/test_csv.c
+++ b/test_csv.c
@@ -112,7 +112,7 @@ test_parser (char *test_name, unsigned char options, void *input, size_t len, st
       retval = csv_parse(&p, input + bytes_processed, bytes, cb1, cb2, test_name);
       if (retval != bytes) {
         if (event_ptr->event_type != CSV_ERR) {
-          fail_parser(test_name, "unexpected parse error occured");
+          fail_parser(test_name, "unexpected parse error occurred");
         } else {
           csv_free(&p);
           return;
@@ -125,7 +125,7 @@ test_parser (char *test_name, unsigned char options, void *input, size_t len, st
 
     if (result != 0) {
       if (event_ptr->event_type != CSV_ERR) {
-        fail_parser(test_name, "unexpected parse error occured");
+        fail_parser(test_name, "unexpected parse error occurred");
       } else {
         csv_free(&p);
         return;


### PR DESCRIPTION
- accomodate -> accommodate
- ambigious -> ambiguous
- carraige -> carriage
- neccessary -> necessary
- occured -> occurred
- preceeding -> preceding
- seperate -> separate
- seperated -> separated
- seperator -> separator
- similiarly -> similarly