### PR TITLE
Fix csv.h include in documentation and examples

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -22,7 +22,7 @@ accomplish that:
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
-#include "csv.h"
+#include <csv.h>
 
 int in_comment, in_record;
 

--- a/csv.3
+++ b/csv.3
@@ -4,7 +4,7 @@ csv \- CSV parser and writer library
 .SH SYNOPSIS
 .nf
 .ft B
-#include <libcsv/csv.h>
+#include <csv.h>
 .LP
 .fi
 .ft B
@@ -516,7 +516,7 @@ mode and handles multiple files.
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "libcsv/csv.h"
+#include <csv.h>
 
 struct counts {
   long unsigned fields;

--- a/examples/csvfix.c
+++ b/examples/csvfix.c
@@ -7,7 +7,7 @@ csvfix - reads (possibly malformed) CSV data from input file
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include "csv.h"
+#include <csv.h>
 
 void cb1 (void *s, size_t i, void *outfile) {
   csv_fwrite((FILE *)outfile, s, i);

--- a/examples/csvinfo.c
+++ b/examples/csvinfo.c
@@ -7,7 +7,7 @@ csvinfo - reads CSV data from input file(s) and reports the number
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "csv.h"
+#include <csv.h>
 
 struct counts {
   long unsigned fields;

--- a/examples/csvtest.c
+++ b/examples/csvtest.c
@@ -8,7 +8,7 @@ csvtest - reads CSV data from stdin and output properly formed equivalent
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include "csv.h"
+#include <csv.h>
 
 static int put_comma;
 

--- a/examples/csvvalid.c
+++ b/examples/csvvalid.c
@@ -7,7 +7,7 @@ csvvalid - determine if files are properly formed CSV files and display
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include "csv.h"
+#include <csv.h>
 
 int
 main (int argc, char *argv[])


### PR DESCRIPTION
The canonical include for the library is `csv.h` from a system location, so adapt documentation and examples.